### PR TITLE
use `--no-cache-dir` flag to `pip` in dockerfiles to save space

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN DEBIAN_FRONTEND=noninteractive \
     openssh-client curl \
     && apt-get clean \
     && apt-get autoremove -y \
-    && pip install pyOpenSSL ansible hpOneView==5.0.0b0 \
+    && pip install --no-cache-dir pyOpenSSL ansible hpOneView==5.0.0b0 \
     && rm -rf /var/lib/apt/lists/* /tmp/* /root/.cache \
     && curl -SL https://github.com/HewlettPackard/oneview-ansible/archive/v${ONEVIEW_ANSIBLE_VERSION}.tar.gz | \
     tar xz \


### PR DESCRIPTION
using "--no-cache-dir" flag in pip install ,make sure downloaded packages
by pip don't cached on system . This is a best practice which make sure
to fetch from repo instead of using local cached one . Further , in case
of Docker Containers , by restricting caching , we can reduce image size.
In term of stats , it depends upon the number of python packages
multiplied by their respective size . e.g for heavy packages with a lot
of dependencies it reduce a lot by don't caching pip packages.

Further , more detail information can be found at

https://medium.com/sciforce/strategies-of-docker-images-optimization-2ca9cc5719b6

Signed-off-by: Pratik raj <rajpratik71@gmail.com>